### PR TITLE
Fix .String() on nested messages

### DIFF
--- a/internal/impl/message.go
+++ b/internal/impl/message.go
@@ -82,10 +82,12 @@ func (mi *MessageInfo) initOnce() {
 	}
 
 	t := mi.GoReflectType
-	if t.Kind() != reflect.Ptr && t.Elem().Kind() != reflect.Struct {
-		panic(fmt.Sprintf("got %v, want *struct kind", t))
+	if t.Kind() != reflect.Struct {
+		if t.Kind() != reflect.Ptr && t.Elem().Kind() != reflect.Struct {
+			panic(fmt.Sprintf("got %v, want *struct kind", t))
+		}
+		t = t.Elem()
 	}
-	t = t.Elem()
 
 	si := mi.makeStructInfo(t)
 	mi.makeReflectFuncs(t, si)

--- a/internal/impl/message_reflect_gen.go
+++ b/internal/impl/message_reflect_gen.go
@@ -9,6 +9,7 @@ package impl
 import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoiface"
+	"reflect"
 )
 
 func (m *messageState) Descriptor() protoreflect.MessageDescriptor {
@@ -144,7 +145,12 @@ func (m *messageReflectWrapper) Interface() protoreflect.ProtoMessage {
 	return (*messageIfaceWrapper)(m)
 }
 func (m *messageReflectWrapper) protoUnwrap() interface{} {
-	return m.pointer().AsIfaceOf(m.messageInfo().GoReflectType.Elem())
+	// This file is generated so this code needs better home.
+	if m.messageInfo().GoReflectType.Kind() == reflect.Ptr {
+		return m.pointer().AsIfaceOf(m.messageInfo().GoReflectType.Elem())
+	} else {
+		return m.pointer().AsIfaceOf(m.messageInfo().GoReflectType)
+	}
 }
 func (m *messageReflectWrapper) ProtoMethods() *protoiface.Methods {
 	m.messageInfo().init()


### PR DESCRIPTION
Fix .String() method for nested messages.
    
    This patch fixes the only failing etcd/raft test with this prototype:
    
    The nested value is now serialized properly:
    ```
    type:MsgHup to:0 from:0 term:0 logTerm:0 index:0 entries:<Index:5 > commit:0 snapshot:<metadata:<conf_state:<> > > reject:false rejectHint:0 '
    ```
